### PR TITLE
temporary style fix

### DIFF
--- a/presentation.js
+++ b/presentation.js
@@ -1,6 +1,6 @@
 define(function(require, exports, module) {
     main.consumes = [
-        "fs.cache", "menus", "Plugin", "preferences", "settings", "tree", "ui"
+        "menus", "Plugin", "preferences", "settings", "tree", "ui"
     ];
     main.provides = ["c9.ide.cs50.presentation"];
     return main;
@@ -8,7 +8,6 @@ define(function(require, exports, module) {
     function main(options, imports, register) {
         var Plugin = imports.Plugin;
         
-        var fsCache = imports["fs.cache"];
         var menus = imports.menus;
         var prefs = imports.preferences;
         var settings = imports.settings;
@@ -82,14 +81,15 @@ define(function(require, exports, module) {
                 return tree.on("draw", updateTree);
             if (presentationOn) {
                 tree.container.classList.add("presentation-tree");
-                fsCache.model.rowHeightInner = treeRowHeights.presentation;
-                fsCache.model.rowHeight = treeRowHeights.presentation;
+                tree.tree.renderer.model.rowHeight = treeRowHeights.presentation;
+                tree.tree.renderer.model.rowHeightInner = treeRowHeights.presentation;
             }
             else {
                 tree.container.classList.remove("presentation-tree");
-                fsCache.model.rowHeightInner = treeRowHeights.default;
-                fsCache.model.rowHeight = treeRowHeights.default;
+                tree.tree.renderer.model.rowHeightInner = treeRowHeights.default;
+                tree.tree.renderer.model.rowHeight = treeRowHeights.default;
             }
+
             tree.tree.renderer.updateFull();
         }
         
@@ -160,6 +160,7 @@ define(function(require, exports, module) {
             togglePresentationMode(false);
             menuItem = null;
             treeRowHeights = null;
+            presentationOn = false;
         });
     
         register(null, {

--- a/style.css
+++ b/style.css
@@ -1,27 +1,25 @@
-.presentation-tree * {
+/* file tree */
+.presentation-tree .real .tree-row {
     font-size: 20px;
 }
 
-/* file/folder renaming area and name wrapper */
-.presentation-tree .ace_wrapper *, .presentation-tree .caption {
-    line-height: 25px !important;
+/* filename wrapper */
+.presentation-tree .real .caption {
     height: 25px !important;
 }
-/* vetically center file/folder icon and name in tree row */
-.presentation-tree .tree-row span {
-    position: relative;
-    top: 50%;
-    margin-top: -24px !important;
+.presentation-tree .real .extrainfo {
+    position: static !important;
 }
 
-/* prevent text from bouncing up and down upon renaming file/folder */
-.presentation-tree .ace_editor.ace-tm.ace_one-line.ace_tree-editor.ace_focus, 
-.presentation-tree .ace_layer.ace_cursor-layer, 
-.presentation-tree .ace_layer.ace_marker-layer {
-    margin-top: 0px !important;
+/* tree heading and filename wrapper */
+.presentation-tree .real .caption,
+.presentation-tree .real .heading {
+    line-height: normal;
 }
-.presentation-tree .ace_editor.ace-tm.ace_one-line.ace_tree-editor.ace_focus {
-    border-width: 0px !important;
-    padding-top: 0px !important;
-    padding-bottom: 0px !important;
+
+/* vetically center file/folder icon and name in tree row */
+.presentation-tree .real .tree-row span {
+    position: relative;
+    top: 50%;
+    margin-top: -24px;
 }


### PR DESCRIPTION
openfiles doesn't seem to provide easy way to change row height.
width and height of file renaming area aren't calculated correctly
for the new font size. tree doesn't seem to provide way to set
different height to headers (e.g., FAVORITES, FILE SYSTEM, etc) than
that of tree rows (files and folders).

![screenshot from 2016-06-14 04 38 43](https://cloud.githubusercontent.com/assets/7230211/16029584/0ea3d1be-31ea-11e6-9ccd-7b2cebe2e9e9.png)

this temporarily disables presentation mode for openfiles, file
renaming area, and pushes tree headers down a little, until finding
better fixes.

![screenshot from 2016-06-14 04 41 56](https://cloud.githubusercontent.com/assets/7230211/16029630/76d329f6-31ea-11e6-906b-2dee7c6061c6.png)
